### PR TITLE
[IMP] account_reconcile_oca: change color of the suspense reconcile line

### DIFF
--- a/account_reconcile_oca/static/src/scss/reconcile.scss
+++ b/account_reconcile_oca/static/src/scss/reconcile.scss
@@ -88,6 +88,9 @@
                 &.selected {
                     background-color: rgba($o-brand-primary, 0.2);
                 }
+                &.suspense {
+                    color: $o-gray-500;
+                }
             }
         }
     }


### PR DESCRIPTION
Proposal to grey the suspense line.

See the screenshot below :

<img width="1811" height="362" alt="image" src="https://github.com/user-attachments/assets/d49fe08b-e48a-41ec-b195-8d63dff3b576" />
